### PR TITLE
fix: navbar highlighting issue

### DIFF
--- a/frontend/src/components/layout/navbar.jsx
+++ b/frontend/src/components/layout/navbar.jsx
@@ -25,12 +25,13 @@ const Header = () => {
     }
   }, [])
 
+  const currentPath = window.location.pathname;
   const navigation = [
-    { name: 'Home', href: '/home', current: false },
-    { name: 'Tours', href: '/tours', current: true },
-    { name: 'Restaurants and Products', href: '/items', current: false },
-    { name: 'Blogs', href: '/blogs', current: false },
-    { name: 'Feedback and reviews', href: '/feedback', current: false },
+    { id: 0, name: 'Home', href: '/home' },
+    { id: 1, name: 'Tours', href: '/tours' },
+    { id: 2, name: 'Restaurants and Products', href: '/items' },
+    { id: 3, name: 'Blogs', href: '/blogs' },
+    { id: 4, name: 'Feedback and reviews', href: '/feedback' },
   ]
 
   return (
@@ -54,14 +55,14 @@ const Header = () => {
                 </div>
                 <div className="hidden sm:ml-6 sm:block h-ful">
                   <div className="flex items-center space-x-4 h-full">
-                    {navigation.map((item) => (
+                    {navigation.map(({id, name, href}) => (
                       <a
-                        key={item.name}
-                        href={item.href}
-                        className={classNames(item.current ? 'border-b-4 border-primary text-primary' : 'text-gray-800 hover:border-b-4 hover:border-gray-700 hover:text-gray-800', 'h-full px-3 py-[1.09rem] pt-[1.4rem] text-sm font-medium')}
-                        aria-current={item.current ? 'page' : undefined}
+                        key={id}
+                        href={href}
+                        className={classNames(currentPath.startsWith(href) ? 'border-b-4 border-primary text-primary' : 'text-gray-800 hover:border-b-4 hover:border-gray-700 hover:text-gray-800', 'h-full px-3 py-[1.09rem] pt-[1.4rem] text-sm font-medium')}
+                        aria-current={currentPath.startsWith(href) ? 'page' : null}
                       >
-                        {item.name}
+                        {name}
                       </a>
                     ))}
                   </div>


### PR DESCRIPTION
I initially wanted to use a regular comparison between the current path and the href of the navigation item, but that wouldn't work with nested paths. So I opted for a better solution and used startsWith() instead